### PR TITLE
Fix XML parsing error in SVG file

### DIFF
--- a/architecture.svg
+++ b/architecture.svg
@@ -31,7 +31,7 @@
     
     <g transform="translate(275, 80)">
         <rect x="0" y="0" width="200" height="80" rx="10" ry="10" fill="url(#grad1)" filter="url(#shadow)" opacity="0.9"/>
-        <text x="100" y="30" text-anchor="middle" font-family="Inter, sans-serif" font-size="16" font-weight="600" fill="white">IDEs & Editors</text>
+        <text x="100" y="30" text-anchor="middle" font-family="Inter, sans-serif" font-size="16" font-weight="600" fill="white">IDEs &amp; Editors</text>
         <text x="100" y="50" text-anchor="middle" font-family="Inter, sans-serif" font-size="12" fill="rgba(255,255,255,0.9)">VSCode, IntelliJ, etc.</text>
         <circle cx="200" cy="40" r="8" fill="#10b981"/>
     </g>


### PR DESCRIPTION
## 🐛 Bug Fix: SVG XML Parsing Error

### Issue:
The architecture diagram SVG file had an XML parsing error that prevented it from displaying correctly in Chrome:

```
This page contains the following errors:
error on line 34 at column 135: xmlParseEntityRef: no name
Below is a rendering of the page up to the first error.
```

### Root Cause:
Line 34 of `architecture.svg` contained an unescaped ampersand (`&`) in the text "IDEs & Editors". In XML/HTML, ampersands must be escaped as `&amp;`.

### Fix:
- Changed `IDEs & Editors` to `IDEs &amp; Editors`
- SVG file now validates with `xmllint --noout architecture.svg`
- No other XML issues found

### Validation:
1. **XML Validation**: `xmllint --noout architecture.svg` passes
2. **Browser Testing**: SVG displays correctly in Chrome without XML errors
3. **Deployed**: Fix is already deployed to production

### Technical Details:
- **File**: `architecture.svg`
- **Line**: 34
- **Change**: Single character escape (`&` → `&amp;`)
- **Impact**: Fixes SVG rendering in all XML-compliant browsers

### Related Issue:
Fixes #1 - Architecture diagram in SVG not displayed

### Deployment Status:
- ✅ Fix deployed to production
- ✅ Website: https://www.niche-robotics.tech
- ✅ SVG: https://www.niche-robotics.tech/architecture.svg
- ✅ Health: https://www.niche-robotics.tech/health

**The SVG architecture diagram now displays correctly without XML parsing errors.**